### PR TITLE
Make plan computation work with threaded code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,15 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         perl-version: ['5.10', '5.14', '5.20']
+        perl-threaded: [false]
         include:
           - perl-version: '5.30'
             os: ubuntu-latest
             release-test: true
             coverage: true
+          - perl-version: '5.30'
+            os: ubuntu-latest
+            perl-threaded: true
     steps:
       - uses: actions/checkout@v2
       - name: Ubuntu packages
@@ -27,6 +31,7 @@ jobs:
         with:
           distribution: strawberry # ignored non-windows
           perl-version: ${{ matrix.perl-version }}
+          multi-thread: ${{ matrix.perl-threaded }}
       - run: cpanm -n PDL::Core::Dev IPC::Run # configure requires
       - run: cpanm -n --installdeps .
       - run: perl -V

--- a/FFTW3_header_include.pm
+++ b/FFTW3_header_include.pm
@@ -3,9 +3,11 @@
 
 use PDL::Types;
 use List::Util 'reduce';
+use threads::shared;
 
-# when I compute an FFTW plan, it goes here
-my %existingPlans;
+# When I compute an FFTW plan, it goes here.
+# This is :shared so that it can be used with Perl threads.
+my %existingPlans :shared;
 
 # these are for the unit tests
 our $_Nplans = 0;
@@ -384,6 +386,7 @@ sub getPlan
                     @dims);
   if ( !exists $existingPlans{$planID} )
   {
+    lock(%existingPlans);
     $existingPlans{$planID} = compute_plan( \@dims, $do_double_precision, $is_real_fft, $do_inverse_fft,
                                             $in, $out, $in_alignment, $out_alignment );
     $_Nplans++;

--- a/MANIFEST
+++ b/MANIFEST
@@ -7,6 +7,7 @@ Makefile.PL
 MANIFEST			This list of files
 README.pod
 t/fftw.t
+t/threads.t
 template_complex.c
 template_real.c
 TODO

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -90,6 +90,11 @@ $descriptor{META_MERGE} = {
         'CPAN::Changes' => 0,
       },
     },
+    test => {
+      requires => {
+        'Test::More' => '0.98',
+      },
+    },
   },
 };
 

--- a/t/threads.t
+++ b/t/threads.t
@@ -1,0 +1,67 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use PDL::LiteF;
+
+my $can_use_threads = eval 'use threads; 1'; ## no critic (eval)
+use Test::More;
+if( ! $can_use_threads ) {
+	plan skip_all => "perl does not support threads";
+} else {
+	plan tests => 1;
+	$PDL::no_clone_skip_warning = 1;
+	require PDL::FFTW3;
+	PDL::FFTW3->import('rfft1');
+	require Thread::Semaphore;
+}
+
+my $s = Thread::Semaphore->new();
+
+sub run_fft {
+	note "Running in thread #" . threads->self->tid;
+	for my $size_factor (1..10) {
+		my $xvals = sequence($size_factor * 100);
+		my $x = sin( $xvals * 2.0 ) + 2.0 * cos( $xvals / 3.0 );
+		my $F = rfft1( $x );
+	}
+	$s->down;
+
+	return 1;
+}
+
+subtest "Running FFTW in threads" => sub {
+	eval {
+		local $SIG{ALRM} = sub { die "alarm\n" };
+		alarm 4; # timeout in 4 seconds
+
+		my @threads;
+		for (0..7) {
+			push @threads, threads->create(\&run_fft);
+			$s->up;
+		}
+
+		$s->down;
+		for my $thr (@threads) {
+			my ($return) = $thr->join;
+			if( ! $return ) {
+				fail "Thread #@{[ $thr->tid ]} did not complete successfully";
+				return;
+			}
+		}
+
+		alarm 0;
+	};
+	if ($@) {
+		if($@ eq "alarm\n") {
+			fail "Threads hanging";
+		} else {
+			die $@;
+		}
+
+	}
+
+	pass "All threads returned successfully";
+};
+
+done_testing;


### PR DESCRIPTION
This will lock access to the computed plan cache so that only one thread
at a time can create a plan.

See <http://fftw.org/fftw3_doc/Thread-safety.html> for more information.
